### PR TITLE
Mark encoded chunk metadata as optional parameter

### DIFF
--- a/src/muxer.ts
+++ b/src/muxer.ts
@@ -218,7 +218,7 @@ export class Muxer<T extends Target> {
 		return configBytes;
 	}
 
-	addVideoChunk(sample: EncodedVideoChunk, meta: EncodedVideoChunkMetadata, timestamp?: number) {
+	addVideoChunk(sample: EncodedVideoChunk, meta?: EncodedVideoChunkMetadata, timestamp?: number) {
 		let data = new Uint8Array(sample.byteLength);
 		sample.copyTo(data);
 
@@ -238,7 +238,7 @@ export class Muxer<T extends Target> {
 		this.#addSampleToTrack(this.#videoTrack, data, type, timestamp, duration, meta);
 	}
 
-	addAudioChunk(sample: EncodedAudioChunk, meta: EncodedAudioChunkMetadata, timestamp?: number) {
+	addAudioChunk(sample: EncodedAudioChunk, meta?: EncodedAudioChunkMetadata, timestamp?: number) {
 		let data = new Uint8Array(sample.byteLength);
 		sample.copyTo(data);
 


### PR DESCRIPTION
The `EncodedVideoChunkOutputCallback` type in [`@types/dom-webcodecs`][1] don't seem to match the official [Typescript types][0]. Since the typescript types appear to better resemble [the spec][2], I've chosen mark the metadata parameter as optional.

[0]: https://github.com/microsoft/TypeScript/blob/634d3a1db5c69c1425119a74045790a4d1dc3046/src/lib/dom.generated.d.ts#L26747
[1]: https://github.com/DefinitelyTyped/DefinitelyTyped/blob/e0a523bfc38585ac3eec98a7818283973c8bdf3c/types/dom-webcodecs/webcodecs.generated.d.ts#L391
[2]: https://www.w3.org/TR/webcodecs/#videoencoder-interface