### PR TITLE
Add build script & publish workflow with provenance

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,44 @@
+name: Release
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+jobs:
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20.x"
+
+      # Get the 'version' field out of the package.json file
+      - name: Get package.json version
+        id: package-json-version
+        run: echo "version=$(cat package.json | jq '.version' --raw-output)" >> $GITHUB_OUTPUT
+
+      # Abort if the version in the package.json file doesn't match the tag name of the release
+      - name: Check package.json version against tag name
+        if: steps.package-json-version.outputs.version != github.event.release.tag_name
+        uses: actions/github-script@v3
+        with:
+          script: core.setFailed('Release tag does not match package.json version!')
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build the package
+        run: npm build
+
+      - name: Create Publish to npm
+        run: npm publish --provenance
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/build.mjs
+++ b/build.mjs
@@ -1,4 +1,5 @@
 import * as esbuild from 'esbuild';
+import process from 'node:process';
 
 const baseConfig = {
 	entryPoints: ['src/index.ts'],
@@ -43,4 +44,23 @@ let ctxEsmMinified = await esbuild.context({
 	minify: true
 });
 
-await Promise.all([ctxUmd.watch(), ctxEsm.watch(), ctxUmdMinified.watch(), ctxEsmMinified.watch()]);
+if (process.argv[2] === '--watch') {
+	await Promise.all([
+		ctxUmd.watch(),
+		ctxEsm.watch(),
+		ctxUmdMinified.watch(),
+		ctxEsmMinified.watch(),
+	]);
+} else {
+	ctxUmd.rebuild();
+	ctxEsm.rebuild();
+	ctxUmdMinified.rebuild();
+	ctxEsmMinified.rebuild();
+
+	await Promise.all([
+		ctxUmd.dispose(),
+		ctxEsm.dispose(),
+		ctxUmdMinified.dispose(),
+		ctxEsmMinified.dispose(),
+	]);
+}

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "build/mp4-muxer.d.ts"
   ],
   "scripts": {
-    "watch": "node build.mjs",
+    "build": "node build.mjs",
+    "watch": "node build.mjs --watch",
     "check": "npx tsc --noEmit --skipLibCheck",
     "lint": "npx eslint src demo build"
   },


### PR DESCRIPTION
This PR does 2 things:

1. Add a `build` script to only build the code once
2. Add a CI workflow to automatically build and publish the package to npm with provenance enabled

See the respective commit messages for more details.

Read up on provenance here: https://github.blog/security/supply-chain-security/introducing-npm-package-provenance/

You will need to add a `NPM_TOKEN` secret to the repository and publish/tag releases on GitHub to trigger the release.