### PR TITLE
Declaration fix for TypeScript 5.6.3

### DIFF
--- a/build/mp4-muxer.d.ts
+++ b/build/mp4-muxer.d.ts
@@ -220,10 +220,6 @@ declare class Muxer<T extends Target> {
 	finalize(): void;
 }
 
-declare global {
-	let Mp4Muxer: typeof Mp4Muxer;
-}
-
 export {
 	Muxer,
 	MuxerOptions,


### PR DESCRIPTION
When using mp4-muxer with TS 5.6.3, you get the following errors in its type declaration:

```
TS2451: Cannot redeclare block-scoped variable Mp4Muxer
mp4-muxer. d. ts(235, 21): Mp4Muxer was also declared here.

TS2502: Mp4Muxer is referenced directly or indirectly in its own type annotation
```

This PR fixes those type errors